### PR TITLE
Ignore iFrame

### DIFF
--- a/ldf.js
+++ b/ldf.js
@@ -1,7 +1,7 @@
 var ldf = {
 	mainselector: "#ldf",
 	notfound: "<div>Page not Found</div>",
-	waitselector: "link[rel='stylesheet'],:not(script)[src]",
+	waitselector: "link[rel='stylesheet'],:not(script)[src]:not(iframe)",
 	pagedir: "pages",
 	baseurl: "",
 	begin: undefined,

--- a/ldf.js
+++ b/ldf.js
@@ -1,7 +1,7 @@
 var ldf = {
 	mainselector: "#ldf",
 	notfound: "<div>Page not Found</div>",
-	waitselector: "link[rel='stylesheet'],:not(script)[src]:not(iframe)",
+	waitselector: "link[rel='stylesheet'],:not(script):not(iframe)[src]",
 	pagedir: "pages",
 	baseurl: "",
 	begin: undefined,


### PR DESCRIPTION
iFrames are loaded async by nature, they dont have to be waited for, otherwise sites with iFrames may load longer than expected